### PR TITLE
Set more flexible dependencies version constraints

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,8 +2,8 @@
   "name": "shoppingfeed/paginator",
   "require": {
     "php": ">= 5.6",
-    "shoppingfeed/iterator": "1.1.0",
-    "shoppingfeed/exception": "1.*"
+    "shoppingfeed/iterator": "^1.1",
+    "shoppingfeed/exception": "^1.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^5.7"


### PR DESCRIPTION
La version fixée de iterator est un peu trop contraignante. Il faudrait qu'on définisse des standards pour nos librairies, mais le mieux il me semble serait de fonctionner comme les autres librairies et permettre toutes montée en version non majeur ("package": "^x.y").