### PR TITLE
Call the paginator iterator instead of toArray adapter

### DIFF
--- a/src/Paginator.php
+++ b/src/Paginator.php
@@ -130,9 +130,7 @@ class Paginator implements PaginationProviderInterface, PaginatorInterface
      */
     public function toArray()
     {
-        $this->paginate();
-
-        return $this->adapter->toArray();
+        return iterator_to_array($this->getIterator());
     }
 
     /**

--- a/tests/unit/PaginatorTest.php
+++ b/tests/unit/PaginatorTest.php
@@ -87,8 +87,8 @@ class PaginatorTest extends TestCase
 
         $this->adapter
             ->expects($this->once())
-            ->method('toArray')
-            ->willReturn($expected = ['one', 'two'])
+            ->method('getIterator')
+            ->willReturn(new \ArrayIterator($expected = [1, 2]))
         ;
 
         $this->assertSame($expected, $this->instance->toArray());


### PR DESCRIPTION
- Before this fix, the toArray() method did not apply Paginator filters on loop