### PR TITLE
Fix type issue

### DIFF
--- a/src/Adapter/InPlacePaginatorAdapter.php
+++ b/src/Adapter/InPlacePaginatorAdapter.php
@@ -37,10 +37,12 @@ class InPlacePaginatorAdapter extends AbstractPaginatorAdapter
             $iterator = $iterator->getIterator();
         }
 
+        $limit = (int) $this->getLimit();
+
         return new \LimitIterator(
             $iterator,
             $this->getOffset(),
-            $this->getLimit() ?: -1
+            $limit ?: -1
         );
     }
 


### PR DESCRIPTION
### Description
Fix following issue in php 8.1
```text
Deprecated: LimitIterator::__construct(): Passing null to parameter #2 ($offset) of type int is deprecated in /var/www/vendor/shoppingfeed/paginator/src/Adapter/InPlacePaginatorAdapter.php on line 43
```