### PR TITLE
Use internal setCurrentPage to allow behavior overwrite

### DIFF
--- a/src/PaginatedIterator.php
+++ b/src/PaginatedIterator.php
@@ -58,7 +58,7 @@ class PaginatedIterator extends AbstractIterator implements PaginatorInterface
             }
 
             $currentPage += 1;
-            $this->paginator->setCurrentPage($currentPage);
+            $this->setCurrentPage($currentPage);
         }
     }
 


### PR DESCRIPTION
### Description
Use internal setCurrentPage to allow behavior overwrite

Then, I will add class below on legacy.

```php
<?php

namespace ShoppingFeed\Channel\Common\Export\Infrastructure;

use ShoppingFeed\Paginator\Adapter\PaginatorAdapterInterface;
use ShoppingFeed\Paginator\PaginatedIterator;
use ShoppingFeed\Paginator\Paginator;

/**
 * $increment parameter allows to not increment page when getting next page, it can be useful when result of query
 * is modified between 2 pagination.
 * For example, your query return 41 results, and you paginate by 10 items. If you remove the 10 items of the first
 * page before requesting the next page (i.e. result 11 to 20), you will get result from 21 to 30 regarding
 * the initial results.
 * In such case, you can use $increment to always get the first page at each iteration instead of incrementing.
 */
class OnTheSpotIterator extends PaginatedIterator
{
    public static function withAdapter(PaginatorAdapterInterface $adapter): self
    {
        return new self(new Paginator($adapter));
    }

    public function setCurrentPage($number): PaginatedIterator
    {
        return $this;
    }
}
```